### PR TITLE
Add Callbacks to Transaction.Send

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "dsa-connect",
-  "version": "0.2.6",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "dsa-connect",
-      "version": "0.2.6",
+      "version": "0.4.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.10.1",
@@ -17,6 +16,7 @@
         "@babel/preset-env": "^7.10.2",
         "@nomiclabs/hardhat-ethers": "^2.0.1",
         "@nomiclabs/hardhat-web3": "^2.0.0",
+        "@rollup/plugin-commonjs": "^18.0.0",
         "@types/inquirer": "^7.3.1",
         "@types/jest": "^26.0.14",
         "@types/node-fetch": "^2.5.10",
@@ -43,6 +43,7 @@
         "ts-node": "^9.1.1",
         "tslib": "^2.0.1",
         "typescript": "^4.0.3",
+        "wait-for-expect": "^3.0.2",
         "web3": "^1.2.6",
         "webpack": "^4.42.1",
         "webpack-cli": "^3.3.11",
@@ -24497,6 +24498,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/wait-for-expect": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz",
+      "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==",
+      "dev": true
+    },
     "node_modules/walker": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
@@ -46867,6 +46874,12 @@
       "requires": {
         "xml-name-validator": "^3.0.0"
       }
+    },
+    "wait-for-expect": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz",
+      "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==",
+      "dev": true
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "ts-node": "^9.1.1",
     "tslib": "^2.0.1",
     "typescript": "^4.0.3",
+    "wait-for-expect": "^3.0.2",
     "web3": "^1.2.6",
     "webpack": "^4.42.1",
     "webpack-cli": "^3.3.11",

--- a/src/dsa.ts
+++ b/src/dsa.ts
@@ -6,7 +6,7 @@ import { CastHelpers } from './cast-helpers'
 import { Addresses } from './addresses'
 import { Internal, Version } from './internal'
 import { Spells } from './spells'
-import { Transaction } from './transaction'
+import { Transaction, TransactionCallbacks } from './transaction'
 import { wrapIfSpells } from './utils'
 import { Instapool_v2 } from './resolvers/instapool_v2'
 import { Erc20 } from './utils/erc20'
@@ -51,7 +51,7 @@ interface Instance {
 type CastParams = {
   spells: Spells
   origin?: string
-} & Pick<TransactionConfig, 'from' | 'to' | 'value' | 'gas' | 'gasPrice' | 'nonce'>
+} & TransactionCallbacks & Pick<TransactionConfig, 'from' | 'to' | 'value' | 'gas' | 'gasPrice' | 'nonce'>
 
 /**
  * @param {address} _d.authority (optional)
@@ -66,7 +66,7 @@ type BuildParams = {
   authority?: string
   origin?: string
   version?: Instance['version']
-} & Pick<TransactionConfig, 'from' | 'gas' | 'gasPrice' | 'nonce'>
+} & TransactionCallbacks & Pick<TransactionConfig, 'from' | 'gas' | 'gasPrice' | 'nonce'>
 
 export class DSA {
   readonly config: DSAConfig
@@ -223,7 +223,10 @@ export class DSA {
       nonce: mergedParams.nonce,
     })
 
-    const transaction = await this.transaction.send(transactionConfig)
+    const transaction = await this.transaction.send(transactionConfig, {
+      onReceipt: mergedParams.onReceipt,
+      onConfirmation: mergedParams.onConfirmation,
+    })
 
     return transaction
   }
@@ -379,7 +382,10 @@ export class DSA {
     console.log(`DSA config:\n version: ${this.instance.version}\n chainId: ${this.instance.chainId}`)
     console.log(`Casting spells to DSA(#${this.instance.id})...`)
 
-    const transaction = await this.transaction.send(transactionConfig)
+    const transaction = await this.transaction.send(transactionConfig, {
+      onReceipt : mergedParams.onReceipt,
+      onConfirmation : mergedParams.onConfirmation,
+    })
 
     return transaction
   }

--- a/test/dsa.spec.ts
+++ b/test/dsa.spec.ts
@@ -1,4 +1,5 @@
 import { config } from 'dotenv'
+import waitForExpect from 'wait-for-expect'
 import Web3 from 'web3'
 // import hre from 'hardhat'
 // import "@nomiclabs/hardhat-ethers"
@@ -820,6 +821,31 @@ describe('DSA v2', function () {
       to: dsa.instance.address
     }
     await dsa.erc20.approve(data)
+  })
+})
+
+describe('Transaction', function(){
+ 
+  test('Should notify on receipt', async () => {
+    const spells = dsa.Spell()
+    const amt = web3.utils.toWei("1", "ether")
+    spells.add({
+      connector: 'uniswap',
+      method: 'sell',
+      args: [usdcAddr, ethAddr, amt, 0, 0, 0],
+    })
+
+    const mockOnReceiptCallback = jest.fn();
+
+    const txHash = await spells.cast({ from: account, onReceipt: mockOnReceiptCallback})
+    
+    expect(txHash).toBeDefined()
+
+   await waitForExpect(() => {
+      expect(mockOnReceiptCallback).toBeCalled()
+      // Check that the receipt was received
+      expect(mockOnReceiptCallback.mock.calls[0][0]).toBeDefined()
+    })
   })
 })
 


### PR DESCRIPTION
this PR allow us to wait for receipt and confirmation using callbacks
```js
const spells = dsa.value.Spell()

spells.add({
	  connector: 'aave_v2',
	  method: 'withdraw',
	  args: ['0x123213', '123213', 0, 0],
})

const txHash = await dsa.value.cast({
	  spells,
	  onReceipt: (receipt) => {
	  	console.log(receipt);
	  },
	  onConfirmation: (confirmationNumber, receipt, latestBlockHash) => {
		console.log(confirmationNumber, receipt, latestBlockHash);
	  }
})
```